### PR TITLE
Fixed parameter name xml_declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ DeviceClient.prototype.callAction = function(serviceId, actionName, params, call
 
     var doc = new et.ElementTree(envelope);
     var xml = doc.write({ 
-      xml_delaration: true,
+      xml_declaration: true,
     });
 
     // Send action request


### PR DESCRIPTION
I noticed the name of the parameter "xml_declaration" was wrong when writing the text of the XML tree.
