### PR TITLE
1.0.3 - added automatic selection of iface for subscription server / Bugfix for subscriptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -364,6 +364,9 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
             listener(e);
           });
         });
+        
+        // be sure we quit response by sending back a 200 OK, otherwise well developed UPNP Devices will kick us out of their subscription list
+        res.end();
 
       }));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upnp-device-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A simple and versatile UPnP device client",
   "author": "thibauts",
   "license": "MIT",
@@ -9,7 +9,7 @@
     "concat-stream": "^1.4.8",
     "debug": "^2.1.3",
     "elementtree": "~0.1.6",
-    "network-address": "^1.0.0"
+    "ip": "^1.1.4"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Hi,

I have added a automatic selection of the interface where the subscriber server resides on.
This solves the problem of 2 active NIC's wherby the UPNP-device resides on the "second" nic and the subscriber server would use the first NIC for listening to the subscription events. (Will never get the events in this case)

It works only if the HOSTNAME of the client is an ip. The resolving of the name is not implemeneted. If its no ip then the code should behave as it is like now and use the first nic.