### PR TITLE
fix: incorrect content-length value in headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ DeviceClient.prototype.callAction = function(serviceId, actionName, params, call
     options.method = 'POST';
     options.headers = {
       'Content-Type': 'text/xml; charset="utf-8"',
-      'Content-Length': xml.length,
+      'Content-Length': Buffer.from(xml).length,
       'Connection': 'close',
       'SOAPACTION': '"' + service.serviceType + '#' + actionName + '"'
     };


### PR DESCRIPTION
Hello! This PR fixes "socket hang up" issue when I'm trying to send contents including Chinese characters. The "content-length" should be the byte length of the buffer rather than the string length, or the remote server may close the connection too early and truncate the posting content unexpectedly.