### PR TITLE
send response to notify requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,6 +350,8 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
         var idx = sids.indexOf(sid);
         if(idx === -1) {
           debug('WARNING unknown SID %s', sid);
+          res.writeHead(404);
+          res.end()
           // silently ignore unknown SIDs
           return;
         }
@@ -364,6 +366,8 @@ DeviceClient.prototype.ensureEventingServer = function(callback) {
             listener(e);
           });
         });
+        res.writeHead(200);
+        res.end();
 
       }));
 


### PR DESCRIPTION
Not sending a response may lead to delayed NOTIFY requests from some devices. On my LG TV this leads to a 30 sec delay. If there are multiple events queued on my TV (e.g. when i pause/resume playback multiple times) this will result in NOTIFY events being sent one by one, with a 30 sec delay between each. This PR fixes the issue.